### PR TITLE
Chai asserts added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^9.33.0",
         "@playwright/test": "^1.54.2",
         "@types/node": "^24.2.1",
+        "chai": "^6.0.1",
         "globals": "^16.3.0"
       }
     },
@@ -52,6 +53,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.0.1.tgz",
+      "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "npx playwright test"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@eslint/js": "^9.33.0",
     "@playwright/test": "^1.54.2",
     "@types/node": "^24.2.1",
+    "chai": "^6.0.1",
     "globals": "^16.3.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,10 +48,10 @@ export default defineConfig({
       use: { ...devices["Desktop Firefox"] },
     },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/tests/checkout.spec.js
+++ b/tests/checkout.spec.js
@@ -1,4 +1,6 @@
 import { test, expect } from "@playwright/test";
+import chai from "chai";
+chai.should();
 
 test.describe("checkout page", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -34,55 +36,107 @@ test.describe("checkout page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
+    // Chai should:
+    await page.waitForURL("https://practicesoftwaretesting.com/account");
+    const accountURL = await page.url();
+    accountURL.should.equal("https://practicesoftwaretesting.com/account");
   });
 
   test("Checkout calculates total price correctly", async ({ page }) => {
     // And the User adds one Combination Pliers and two Bolt Cutters to the cart
     await page.goto("/");
-    // One Combination Pliers
     await page.waitForLoadState();
+    // One Combination Pliers
     await expect(page.getByText("Combination Pliers")).toBeVisible();
+    // Chai should:
+    const pliersIsVisible = await page.getByText("Combination Pliers").isVisible();
+    pliersIsVisible.should.be.true;
+
     await page.getByText("Combination Pliers").click();
     await expect(page.locator('[data-test="add-to-cart"]')).toBeVisible();
+    // Chai should:
+    const addToCartVisible = await page.locator('[data-test="add-to-cart"]').isVisible();
+    addToCartVisible.should.be.true;
+
     await page.locator('[data-test="add-to-cart"]').click();
     await expect(page.getByRole("alert", { name: "Product added to shopping" })).toBeVisible();
+    // Chai should:
+    const productAddedVisible = await page.getByRole("alert", { name: "Product added to shopping" }).isVisible();
+    productAddedVisible.should.be.true;
 
     // Return to Home Page
     await page.getByRole("link", { name: "Practice Software Testing -" }).click();
 
     // Two Bolt Cutters
     await expect(page.getByText("Bolt Cutters")).toBeVisible();
+    // Chai assert:
+    const boltCuttersVisible = await page.getByText("Bolt Cutters").isVisible();
+    boltCuttersVisible.should.be.true;
+
     await page.getByText("Bolt Cutters").click();
     await expect(page.locator('[data-test="increase-quantity"]')).toBeVisible();
+    // Chai assert:
+    const increaseVisible = await page.locator('[data-test="increase-quantity"]').isVisible();
+    increaseVisible.should.be.true;
+
     await page.locator('[data-test="increase-quantity"]').click();
     await expect(page.locator('[data-test="add-to-cart"]')).toBeVisible();
+    // Chai assert:
+    const addCartVisible = await page.locator('[data-test="add-to-cart"]').isVisible();
+    addCartVisible.should.be.true;
+
     await page.locator('[data-test="add-to-cart"]').click();
     await expect(page.getByRole("alert", { name: "Product added to shopping" })).toBeVisible();
+    // Chai assert:
+    const productAddVisible = await page.getByRole("alert", { name: "Product added to shopping" }).isVisible();
+    productAddVisible.should.be.true;
 
     // When the User goes to the Checkout page
-    await page.waitForLoadState();
     await expect(page.locator('[data-test="nav-cart"]')).toBeVisible();
+    // Chai assert:
+    const navCartVisible = await page.locator('[data-test="nav-cart"]').isVisible();
+    navCartVisible.should.be.true;
+
     await page.locator('[data-test="nav-cart"]').click();
+    await page.waitForLoadState();
 
     // And the sub-total price of the Combination Pliers is $14.15
     await expect(page.locator('[data-test="line-price"]', { hasText: "$14.15" })).toBeVisible();
+    // Chai assert:
+    const linePrice1Visible = await page.locator('[data-test="line-price"]', { hasText: "$14.15" }).isVisible();
+    linePrice1Visible.should.be.true;
 
     // And the sub-total price of the Bolt Cutters is $96.82
     await expect(page.locator('[data-test="line-price"]', { hasText: "$96.82" })).toBeVisible();
+    // Chai assert:
+    const linePrice2Visible = await page.locator('[data-test="line-price"]', { hasText: "$96.82" }).isVisible();
+    linePrice2Visible.should.be.true;
 
     // Then the total price of the cart is $110.97
     await expect(page.locator('[data-test="cart-total"]', { hasText: "$110.97" })).toBeVisible();
+    // Chai assert:
+    const cartTotalVisible = await page.locator('[data-test="cart-total"]', { hasText: "$110.97" }).isVisible();
+    cartTotalVisible.should.be.true;
 
     await page.waitForLoadState();
 
     // Empty the cart for future re-test
+    await expect(page.getByRole("row", { name: "Combination Pliers  Quantity" }).locator("a")).toBeVisible();
     await page.getByRole("row", { name: "Combination Pliers  Quantity" }).locator("a").click();
     await expect(page.getByRole("alert", { name: "Product deleted." })).toBeVisible();
+    // Chai assert:
+    const productDeleted1Visible = await page.getByRole("alert", { name: "Product deleted." }).isVisible();
+    productDeleted1Visible.should.be.true;
+
     await page.getByRole("row", { name: "Bolt Cutters Quantity" }).locator("a").click();
     await expect(page.getByRole("alert", { name: "Product deleted." })).toBeVisible();
-
-    await page.waitForLoadState();
+    // Chai assert:
+    const productDeleted2Visible = await page.getByRole("alert", { name: "Product deleted." }).isVisible();
+    productDeleted2Visible.should.be.true;
 
     await expect(page.getByText("The cart is empty. Nothing to")).toBeVisible();
+    // Chai assert:
+    const cartEmptyVisible = await page.getByText("The cart is empty. Nothing to").isVisible();
+    cartEmptyVisible.should.be.true;
   });
 });

--- a/tests/checkout.spec.js
+++ b/tests/checkout.spec.js
@@ -34,7 +34,7 @@ test.describe("checkout page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await page.waitForURL("https://practicesoftwaretesting.com/account");
-    const accountURL = await page.url();
+    const accountURL = page.url();
     chaiExpect(accountURL).to.equal("https://practicesoftwaretesting.com/account");
   });
 
@@ -44,21 +44,21 @@ test.describe("checkout page", () => {
     await page.waitForLoadState();
 
     // One Combination Pliers:
-    const pliers = await page.getByText("Combination Pliers");
+    const pliers = page.getByText("Combination Pliers");
     await pliers.waitFor({ state: "visible", timeout: 3500 });
     const pliersIsVisible = await pliers.isVisible();
     chaiExpect(pliersIsVisible).to.be.true;
 
     await pliers.click();
 
-    const addToCart = await page.locator('[data-test="add-to-cart"]');
+    const addToCart = page.locator('[data-test="add-to-cart"]');
     await addToCart.waitFor({ state: "visible", timeout: 3500 });
     const addToCartVisible = await addToCart.isVisible();
     chaiExpect(addToCartVisible).to.be.true;
 
     await addToCart.click();
 
-    const productAdded = await page.getByRole("alert", { name: "Product added to shopping" });
+    const productAdded = page.getByRole("alert", { name: "Product added to shopping" });
     await productAdded.waitFor({ state: "visible", timeout: 3500 });
     const productAddedVisible = await productAdded.isVisible();
     chaiExpect(productAddedVisible).to.be.true;
@@ -68,7 +68,7 @@ test.describe("checkout page", () => {
     await page.waitForLoadState();
 
     // Two Bolt Cutters
-    const boltCutters = await page.getByText("Bolt Cutters");
+    const boltCutters = page.getByText("Bolt Cutters");
     await boltCutters.waitFor({ state: "visible", timeout: 3500 });
     const boltCuttersVisible = await boltCutters.isVisible();
     chaiExpect(boltCuttersVisible).to.be.true;
@@ -76,27 +76,27 @@ test.describe("checkout page", () => {
     await boltCutters.click();
     await page.waitForLoadState();
 
-    const increase = await page.locator('[data-test="increase-quantity"]');
+    const increase = page.locator('[data-test="increase-quantity"]');
     await increase.waitFor({ state: "visible", timeout: 3500 });
     const increaseVisible = await increase.isVisible();
     chaiExpect(increaseVisible).to.be.true;
 
     await increase.click();
 
-    const addCart = await page.locator('[data-test="add-to-cart"]');
+    const addCart = page.locator('[data-test="add-to-cart"]');
     await addCart.waitFor({ state: "visible", timeout: 3500 });
     const addCartVisible = await addCart.isVisible();
     chaiExpect(addCartVisible).to.be.true;
 
     await addCart.click();
 
-    const productAdd = await page.getByRole("alert", { name: "Product added to shopping" });
+    const productAdd = page.getByRole("alert", { name: "Product added to shopping" });
     await productAdd.waitFor({ state: "visible", timeout: 3500 });
     const productAddVisible = await productAdd.isVisible();
     chaiExpect(productAddVisible).to.be.true;
 
     // When the User goes to the Checkout page
-    const navCart = await page.locator('[data-test="nav-cart"]');
+    const navCart = page.locator('[data-test="nav-cart"]');
     await navCart.waitFor({ state: "visible", timeout: 3500 });
     const navCartVisible = await navCart.isVisible();
     chaiExpect(navCartVisible).to.be.true;
@@ -108,19 +108,19 @@ test.describe("checkout page", () => {
     await page.waitForLoadState();
 
     // And the sub-total price of the Combination Pliers is $14.15
-    const linePrice1 = await page.locator('[data-test="line-price"]', { hasText: "$14.15" });
+    const linePrice1 = page.locator('[data-test="line-price"]', { hasText: "$14.15" });
     await linePrice1.waitFor({ state: "visible", timeout: 3500 });
     const linePrice1Visible = await linePrice1.isVisible();
     chaiExpect(linePrice1Visible).to.be.true;
 
     // And the sub-total price of the Bolt Cutters is $96.82
-    const linePrice2 = await page.locator('[data-test="line-price"]', { hasText: "$96.82" });
+    const linePrice2 = page.locator('[data-test="line-price"]', { hasText: "$96.82" });
     await linePrice2.waitFor({ state: "visible", timeout: 3500 });
     const linePrice2Visible = await linePrice2.isVisible();
     chaiExpect(linePrice2Visible).to.be.true;
 
     // Then the total price of the cart is $110.97
-    const cartTotal = await page.locator('[data-test="cart-total"]', { hasText: "$110.97" });
+    const cartTotal = page.locator('[data-test="cart-total"]', { hasText: "$110.97" });
     await cartTotal.waitFor({ state: "visible", timeout: 3500 });
     const cartTotalVisible = await cartTotal.isVisible();
     chaiExpect(cartTotalVisible).to.be.true;
@@ -128,7 +128,7 @@ test.describe("checkout page", () => {
     await page.waitForLoadState();
 
     // Empty the cart for future re-test
-    const emptyPliers = await page
+    const emptyPliers = page
       .getByRole("row", { name: "Combination Pliers  Quantity" })
       .locator("a");
     await emptyPliers.waitFor({ state: "visible", timeout: 3500 });
@@ -137,27 +137,25 @@ test.describe("checkout page", () => {
 
     await emptyPliers.click();
 
-    const productDeleted = await page.getByRole("alert", { name: "Product deleted." });
+    const productDeleted = page.getByRole("alert", { name: "Product deleted." });
     await productDeleted.waitFor({ state: "visible", timeout: 3500 });
     const productDeletedVisible = await productDeleted.isVisible();
     chaiExpect(productDeletedVisible).to.be.true;
 
-    const emptyBoltCutters = await page
-      .getByRole("row", { name: "Bolt Cutters Quantity" })
-      .locator("a");
+    const emptyBoltCutters = page.getByRole("row", { name: "Bolt Cutters Quantity" }).locator("a");
     await emptyBoltCutters.waitFor({ state: "visible", timeout: 3500 });
     const emptyBoltCuttersVisible = await emptyBoltCutters.isVisible();
     chaiExpect(emptyBoltCuttersVisible).to.be.true;
 
     await emptyBoltCutters.click();
 
-    const productDeleted2 = await page.getByRole("alert", { name: "Product deleted." });
+    const productDeleted2 = page.getByRole("alert", { name: "Product deleted." });
     await productDeleted2.waitFor({ state: "visible", timeout: 3500 });
     const productDeleted2Visible = await productDeleted2.isVisible();
     chaiExpect(productDeleted2Visible).to.be.true;
 
     // Cart completely empty:
-    const cartEmpty = await page.getByText("The cart is empty. Nothing to");
+    const cartEmpty = page.getByText("The cart is empty. Nothing to");
     await cartEmpty.waitFor({ state: "visible", timeout: 5000 });
     const cartEmptyVisible = await cartEmpty.isVisible();
     chaiExpect(cartEmptyVisible).to.be.true;

--- a/tests/checkout.spec.js
+++ b/tests/checkout.spec.js
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
-import chai from "chai";
-chai.should();
+import { expect as chaiExpect } from "chai";
 
 test.describe("checkout page", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -24,10 +23,9 @@ test.describe("checkout page", () => {
     try {
       await page.locator('[data-test="register-submit"]').click();
       await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
-      console.log("cuenta creada");
+      console.log("Account created");
     } catch (err) {
-      await page.getByText("A customer with this email address already exists.");
-      console.log("la cuenta ya estaba creada");
+      console.log("The account was already created");
     }
 
     // Given the user is logged
@@ -35,108 +33,133 @@ test.describe("checkout page", () => {
     await page.locator('[data-test="email"]').fill("email@example.com");
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
-    // Chai should:
     await page.waitForURL("https://practicesoftwaretesting.com/account");
     const accountURL = await page.url();
-    accountURL.should.equal("https://practicesoftwaretesting.com/account");
+    chaiExpect(accountURL).to.equal("https://practicesoftwaretesting.com/account");
   });
 
   test("Checkout calculates total price correctly", async ({ page }) => {
     // And the User adds one Combination Pliers and two Bolt Cutters to the cart
     await page.goto("/");
     await page.waitForLoadState();
-    // One Combination Pliers
-    await expect(page.getByText("Combination Pliers")).toBeVisible();
-    // Chai should:
-    const pliersIsVisible = await page.getByText("Combination Pliers").isVisible();
-    pliersIsVisible.should.be.true;
 
-    await page.getByText("Combination Pliers").click();
-    await expect(page.locator('[data-test="add-to-cart"]')).toBeVisible();
-    // Chai should:
-    const addToCartVisible = await page.locator('[data-test="add-to-cart"]').isVisible();
-    addToCartVisible.should.be.true;
+    // One Combination Pliers:
+    const pliers = await page.getByText("Combination Pliers");
+    await pliers.waitFor({ state: "visible", timeout: 3500 });
+    const pliersIsVisible = await pliers.isVisible();
+    chaiExpect(pliersIsVisible).to.be.true;
 
-    await page.locator('[data-test="add-to-cart"]').click();
-    await expect(page.getByRole("alert", { name: "Product added to shopping" })).toBeVisible();
-    // Chai should:
-    const productAddedVisible = await page.getByRole("alert", { name: "Product added to shopping" }).isVisible();
-    productAddedVisible.should.be.true;
+    await pliers.click();
+
+    const addToCart = await page.locator('[data-test="add-to-cart"]');
+    await addToCart.waitFor({ state: "visible", timeout: 3500 });
+    const addToCartVisible = await addToCart.isVisible();
+    chaiExpect(addToCartVisible).to.be.true;
+
+    await addToCart.click();
+
+    const productAdded = await page.getByRole("alert", { name: "Product added to shopping" });
+    await productAdded.waitFor({ state: "visible", timeout: 3500 });
+    const productAddedVisible = await productAdded.isVisible();
+    chaiExpect(productAddedVisible).to.be.true;
 
     // Return to Home Page
     await page.getByRole("link", { name: "Practice Software Testing -" }).click();
+    await page.waitForLoadState();
 
     // Two Bolt Cutters
-    await expect(page.getByText("Bolt Cutters")).toBeVisible();
-    // Chai assert:
-    const boltCuttersVisible = await page.getByText("Bolt Cutters").isVisible();
-    boltCuttersVisible.should.be.true;
+    const boltCutters = await page.getByText("Bolt Cutters");
+    await boltCutters.waitFor({ state: "visible", timeout: 3500 });
+    const boltCuttersVisible = await boltCutters.isVisible();
+    chaiExpect(boltCuttersVisible).to.be.true;
 
-    await page.getByText("Bolt Cutters").click();
-    await expect(page.locator('[data-test="increase-quantity"]')).toBeVisible();
-    // Chai assert:
-    const increaseVisible = await page.locator('[data-test="increase-quantity"]').isVisible();
-    increaseVisible.should.be.true;
+    await boltCutters.click();
+    await page.waitForLoadState();
 
-    await page.locator('[data-test="increase-quantity"]').click();
-    await expect(page.locator('[data-test="add-to-cart"]')).toBeVisible();
-    // Chai assert:
-    const addCartVisible = await page.locator('[data-test="add-to-cart"]').isVisible();
-    addCartVisible.should.be.true;
+    const increase = await page.locator('[data-test="increase-quantity"]');
+    await increase.waitFor({ state: "visible", timeout: 3500 });
+    const increaseVisible = await increase.isVisible();
+    chaiExpect(increaseVisible).to.be.true;
 
-    await page.locator('[data-test="add-to-cart"]').click();
-    await expect(page.getByRole("alert", { name: "Product added to shopping" })).toBeVisible();
-    // Chai assert:
-    const productAddVisible = await page.getByRole("alert", { name: "Product added to shopping" }).isVisible();
-    productAddVisible.should.be.true;
+    await increase.click();
+
+    const addCart = await page.locator('[data-test="add-to-cart"]');
+    await addCart.waitFor({ state: "visible", timeout: 3500 });
+    const addCartVisible = await addCart.isVisible();
+    chaiExpect(addCartVisible).to.be.true;
+
+    await addCart.click();
+
+    const productAdd = await page.getByRole("alert", { name: "Product added to shopping" });
+    await productAdd.waitFor({ state: "visible", timeout: 3500 });
+    const productAddVisible = await productAdd.isVisible();
+    chaiExpect(productAddVisible).to.be.true;
 
     // When the User goes to the Checkout page
-    await expect(page.locator('[data-test="nav-cart"]')).toBeVisible();
-    // Chai assert:
-    const navCartVisible = await page.locator('[data-test="nav-cart"]').isVisible();
-    navCartVisible.should.be.true;
+    const navCart = await page.locator('[data-test="nav-cart"]');
+    await navCart.waitFor({ state: "visible", timeout: 3500 });
+    const navCartVisible = await navCart.isVisible();
+    chaiExpect(navCartVisible).to.be.true;
 
-    await page.locator('[data-test="nav-cart"]').click();
+    await page.waitForLoadState();
+
+    await navCart.click();
+    await page.waitForURL("/checkout");
     await page.waitForLoadState();
 
     // And the sub-total price of the Combination Pliers is $14.15
-    await expect(page.locator('[data-test="line-price"]', { hasText: "$14.15" })).toBeVisible();
-    // Chai assert:
-    const linePrice1Visible = await page.locator('[data-test="line-price"]', { hasText: "$14.15" }).isVisible();
-    linePrice1Visible.should.be.true;
+    const linePrice1 = await page.locator('[data-test="line-price"]', { hasText: "$14.15" });
+    await linePrice1.waitFor({ state: "visible", timeout: 3500 });
+    const linePrice1Visible = await linePrice1.isVisible();
+    chaiExpect(linePrice1Visible).to.be.true;
 
     // And the sub-total price of the Bolt Cutters is $96.82
-    await expect(page.locator('[data-test="line-price"]', { hasText: "$96.82" })).toBeVisible();
-    // Chai assert:
-    const linePrice2Visible = await page.locator('[data-test="line-price"]', { hasText: "$96.82" }).isVisible();
-    linePrice2Visible.should.be.true;
+    const linePrice2 = await page.locator('[data-test="line-price"]', { hasText: "$96.82" });
+    await linePrice2.waitFor({ state: "visible", timeout: 3500 });
+    const linePrice2Visible = await linePrice2.isVisible();
+    chaiExpect(linePrice2Visible).to.be.true;
 
     // Then the total price of the cart is $110.97
-    await expect(page.locator('[data-test="cart-total"]', { hasText: "$110.97" })).toBeVisible();
-    // Chai assert:
-    const cartTotalVisible = await page.locator('[data-test="cart-total"]', { hasText: "$110.97" }).isVisible();
-    cartTotalVisible.should.be.true;
+    const cartTotal = await page.locator('[data-test="cart-total"]', { hasText: "$110.97" });
+    await cartTotal.waitFor({ state: "visible", timeout: 3500 });
+    const cartTotalVisible = await cartTotal.isVisible();
+    chaiExpect(cartTotalVisible).to.be.true;
 
     await page.waitForLoadState();
 
     // Empty the cart for future re-test
-    await expect(page.getByRole("row", { name: "Combination Pliers  Quantity" }).locator("a")).toBeVisible();
-    await page.getByRole("row", { name: "Combination Pliers  Quantity" }).locator("a").click();
-    await expect(page.getByRole("alert", { name: "Product deleted." })).toBeVisible();
-    // Chai assert:
-    const productDeleted1Visible = await page.getByRole("alert", { name: "Product deleted." }).isVisible();
-    productDeleted1Visible.should.be.true;
+    const emptyPliers = await page
+      .getByRole("row", { name: "Combination Pliers  Quantity" })
+      .locator("a");
+    await emptyPliers.waitFor({ state: "visible", timeout: 3500 });
+    const emptyPliersVisible = await emptyPliers.isVisible();
+    chaiExpect(emptyPliersVisible).to.be.true;
 
-    await page.getByRole("row", { name: "Bolt Cutters Quantity" }).locator("a").click();
-    await expect(page.getByRole("alert", { name: "Product deleted." })).toBeVisible();
-    // Chai assert:
-    const productDeleted2Visible = await page.getByRole("alert", { name: "Product deleted." }).isVisible();
-    productDeleted2Visible.should.be.true;
+    await emptyPliers.click();
 
-    await expect(page.getByText("The cart is empty. Nothing to")).toBeVisible();
-    // Chai assert:
-    const cartEmptyVisible = await page.getByText("The cart is empty. Nothing to").isVisible();
-    cartEmptyVisible.should.be.true;
+    const productDeleted = await page.getByRole("alert", { name: "Product deleted." });
+    await productDeleted.waitFor({ state: "visible", timeout: 3500 });
+    const productDeletedVisible = await productDeleted.isVisible();
+    chaiExpect(productDeletedVisible).to.be.true;
+
+    const emptyBoltCutters = await page
+      .getByRole("row", { name: "Bolt Cutters Quantity" })
+      .locator("a");
+    await emptyBoltCutters.waitFor({ state: "visible", timeout: 3500 });
+    const emptyBoltCuttersVisible = await emptyBoltCutters.isVisible();
+    chaiExpect(emptyBoltCuttersVisible).to.be.true;
+
+    await emptyBoltCutters.click();
+
+    const productDeleted2 = await page.getByRole("alert", { name: "Product deleted." });
+    await productDeleted2.waitFor({ state: "visible", timeout: 3500 });
+    const productDeleted2Visible = await productDeleted2.isVisible();
+    chaiExpect(productDeleted2Visible).to.be.true;
+
+    // Cart completely empty:
+    const cartEmpty = await page.getByText("The cart is empty. Nothing to");
+    await cartEmpty.waitFor({ state: "visible", timeout: 5000 });
+    const cartEmptyVisible = await cartEmpty.isVisible();
+    chaiExpect(cartEmptyVisible).to.be.true;
   });
 });

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -35,7 +35,7 @@ test.describe("home page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await page.waitForURL("https://practicesoftwaretesting.com/account");
-    const accountURL = await page.url();
+    const accountURL = page.url();
     accountURL.should.equal("https://practicesoftwaretesting.com/account");
   });
 
@@ -45,7 +45,7 @@ test.describe("home page", () => {
     await page.waitForLoadState();
 
     // When the User adds only the "Tool Belts" filter
-    const checkboxToolBelts = await page.getByRole("checkbox", { name: "Tool Belts" });
+    const checkboxToolBelts = page.getByRole("checkbox", { name: "Tool Belts" });
     await checkboxToolBelts.waitFor({ state: "visible" });
     const checkboxVisible = await checkboxToolBelts.isVisible();
     checkboxVisible.should.be.true;
@@ -53,7 +53,7 @@ test.describe("home page", () => {
     await checkboxToolBelts.check();
 
     // Then only the "Leather toolbelt" product will be shown
-    const toolBelt = await page.locator('[data-test="product-name"]', {
+    const toolBelt = page.locator('[data-test="product-name"]', {
       hasText: "Leather toolbelt",
     });
     await toolBelt.waitFor({ state: "visible" });
@@ -66,7 +66,7 @@ test.describe("home page", () => {
     await page.goto("/");
 
     // When the User adds only the "Workbench" filter
-    const checkboxWorkbench = await page.getByRole("checkbox", { name: "Workbench" });
+    const checkboxWorkbench = page.getByRole("checkbox", { name: "Workbench" });
     await checkboxWorkbench.waitFor({ state: "visible" });
     const checkboxWorkbenchVisible = await checkboxWorkbench.isVisible();
     checkboxWorkbenchVisible.should.be.true;
@@ -74,7 +74,7 @@ test.describe("home page", () => {
     await checkboxWorkbench.check();
 
     // Then the "There are no products found." message is displayed
-    const noProducts = await page.locator('[data-test="no-results"]', {
+    const noProducts = page.locator('[data-test="no-results"]', {
       hasText: "There are no products found.",
     });
     await noProducts.waitFor({ state: "visible" });

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -1,4 +1,6 @@
 import { test, expect } from "@playwright/test";
+import chai from "chai";
+chai.should();
 
 test.describe("home page", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -34,14 +36,24 @@ test.describe("home page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
+    // Chai should:
+    await page.waitForURL("https://practicesoftwaretesting.com/account");
+    const accountURL = await page.url();
+    accountURL.should.equal("https://practicesoftwaretesting.com/account");
   });
 
   test("Showing products according to filters", async ({ page }) => {
     // And the User is on the Home page
     await page.goto("/");
 
+    await page.waitForLoadState();
+
     // When the User adds only the "Tool Belts" filter
     await expect(page.getByRole("checkbox", { name: "Tool Belts" })).toBeVisible();
+    // Chai assert:
+    const checkboxVisible = await page.getByRole("checkbox", { name: "Tool Belts" }).isVisible();
+    checkboxVisible.should.be.true;
+
     await page.getByRole("checkbox", { name: "Tool Belts" }).check();
 
     // Then only the "Leather toolbelt" product will be shown
@@ -50,6 +62,13 @@ test.describe("home page", () => {
         hasText: "Leather toolbelt",
       })
     ).toBeVisible();
+    // Chai assert:
+    const toolbeltVisible = await page
+      .locator('[data-test="product-name"]', {
+        hasText: "Leather toolbelt",
+      })
+      .isVisible();
+    toolbeltVisible.should.be.true;
   });
 
   test("Not showing products according to filters", async ({ page }) => {
@@ -58,6 +77,10 @@ test.describe("home page", () => {
 
     // When the User adds only the "Workbench" filter
     await expect(page.getByRole("checkbox", { name: "Workbench" })).toBeVisible();
+    // Chai assert:
+    const checkboxVisible = await page.getByRole("checkbox", { name: "Workbench" }).isVisible();
+    checkboxVisible.should.be.true;
+
     await page.getByRole("checkbox", { name: "Workbench" }).check();
 
     // Then the "There are no products found." message is displayed
@@ -66,5 +89,12 @@ test.describe("home page", () => {
         hasText: "There are no products found.",
       })
     ).toBeVisible();
+    // Chai assert:
+    const noProductsVisible = await page
+      .locator('[data-test="no-results"]', {
+        hasText: "There are no products found.",
+      })
+      .isVisible();
+    noProductsVisible.should.be.true;
   });
 });

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -24,10 +24,9 @@ test.describe("home page", () => {
     try {
       await page.locator('[data-test="register-submit"]').click();
       await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
-      console.log("cuenta creada");
+      console.log("Account created");
     } catch (err) {
-      await page.getByText("A customer with this email address already exists.");
-      console.log("la cuenta ya estaba creada");
+      console.log("The account was already created");
     }
 
     // Given the user is logged
@@ -35,8 +34,6 @@ test.describe("home page", () => {
     await page.locator('[data-test="email"]').fill("email@example.com");
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
-    // Chai should:
     await page.waitForURL("https://practicesoftwaretesting.com/account");
     const accountURL = await page.url();
     accountURL.should.equal("https://practicesoftwaretesting.com/account");
@@ -45,30 +42,23 @@ test.describe("home page", () => {
   test("Showing products according to filters", async ({ page }) => {
     // And the User is on the Home page
     await page.goto("/");
-
     await page.waitForLoadState();
 
     // When the User adds only the "Tool Belts" filter
-    await expect(page.getByRole("checkbox", { name: "Tool Belts" })).toBeVisible();
-    // Chai assert:
-    const checkboxVisible = await page.getByRole("checkbox", { name: "Tool Belts" }).isVisible();
+    const checkboxToolBelts = await page.getByRole("checkbox", { name: "Tool Belts" });
+    await checkboxToolBelts.waitFor({ state: "visible" });
+    const checkboxVisible = await checkboxToolBelts.isVisible();
     checkboxVisible.should.be.true;
 
-    await page.getByRole("checkbox", { name: "Tool Belts" }).check();
+    await checkboxToolBelts.check();
 
     // Then only the "Leather toolbelt" product will be shown
-    await expect(
-      page.locator('[data-test="product-name"]', {
-        hasText: "Leather toolbelt",
-      })
-    ).toBeVisible();
-    // Chai assert:
-    const toolbeltVisible = await page
-      .locator('[data-test="product-name"]', {
-        hasText: "Leather toolbelt",
-      })
-      .isVisible();
-    toolbeltVisible.should.be.true;
+    const toolBelt = await page.locator('[data-test="product-name"]', {
+      hasText: "Leather toolbelt",
+    });
+    await toolBelt.waitFor({ state: "visible" });
+    const toolBeltvisible = await toolBelt.isVisible();
+    toolBeltvisible.should.be.true;
   });
 
   test("Not showing products according to filters", async ({ page }) => {
@@ -76,25 +66,19 @@ test.describe("home page", () => {
     await page.goto("/");
 
     // When the User adds only the "Workbench" filter
-    await expect(page.getByRole("checkbox", { name: "Workbench" })).toBeVisible();
-    // Chai assert:
-    const checkboxVisible = await page.getByRole("checkbox", { name: "Workbench" }).isVisible();
-    checkboxVisible.should.be.true;
+    const checkboxWorkbench = await page.getByRole("checkbox", { name: "Workbench" });
+    await checkboxWorkbench.waitFor({ state: "visible" });
+    const checkboxWorkbenchVisible = await checkboxWorkbench.isVisible();
+    checkboxWorkbenchVisible.should.be.true;
 
-    await page.getByRole("checkbox", { name: "Workbench" }).check();
+    await checkboxWorkbench.check();
 
     // Then the "There are no products found." message is displayed
-    await expect(
-      page.locator('[data-test="no-results"]', {
-        hasText: "There are no products found.",
-      })
-    ).toBeVisible();
-    // Chai assert:
-    const noProductsVisible = await page
-      .locator('[data-test="no-results"]', {
-        hasText: "There are no products found.",
-      })
-      .isVisible();
+    const noProducts = await page.locator('[data-test="no-results"]', {
+      hasText: "There are no products found.",
+    });
+    await noProducts.waitFor({ state: "visible" });
+    const noProductsVisible = await noProducts.isVisible();
     noProductsVisible.should.be.true;
   });
 });

--- a/tests/product_details.spec.js
+++ b/tests/product_details.spec.js
@@ -23,10 +23,9 @@ test.describe("product details page", () => {
     try {
       await page.locator('[data-test="register-submit"]').click();
       await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
-      console.log("cuenta creada");
+      console.log("Account created");
     } catch (err) {
-      await page.getByText("A customer with this email address already exists.");
-      console.log("la cuenta ya estaba creada");
+      console.log("The account was already created");
     }
 
     // Given the user is logged
@@ -34,8 +33,6 @@ test.describe("product details page", () => {
     await page.locator('[data-test="email"]').fill("email@example.com");
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
-    // Chai assert:
     await page.waitForURL("https://practicesoftwaretesting.com/account");
     const accountURL = await page.url();
     assert.equal(accountURL, "https://practicesoftwaretesting.com/account");
@@ -46,17 +43,18 @@ test.describe("product details page", () => {
     await page.goto("account/favorites");
     await page.waitForLoadState();
 
-    await expect(page.getByText("There are no favorites yet.")).toBeVisible();
-    // Chai assert:
     const noFavoritesMessage = await page.getByText("There are no favorites yet.");
+    await noFavoritesMessage.waitFor({ state: "visible" });
     const favoritesisVisible = await noFavoritesMessage.isVisible();
-    assert.isTrue(favoritesisVisible, "Expected 'There are no favorites yet.' message to be visible");
+    assert.isTrue(
+      favoritesisVisible,
+      "Expected 'There are no favorites yet.' message to be visible"
+    );
 
     // And the User is on the Combination Pliers page
     await page.goto("/");
-    await expect(page.getByText("Combination Pliers")).toBeVisible();
-    // Chai assert:
     const combinationPliers = await page.getByText("Combination Pliers");
+    await combinationPliers.waitFor({ state: "visible" });
     const combinationPliersisVisible = await combinationPliers.isVisible();
     assert.isTrue(combinationPliersisVisible, "Expected Combination Pliers to be visible.");
 
@@ -65,34 +63,28 @@ test.describe("product details page", () => {
     // When the User adds the Combination Pliers to Favorites
     await page.locator('[data-test="add-to-favorites"]').click();
 
-    // Then the message "Product added to your favorites list." is displayed
-    await expect(page.getByRole("alert", { name: "Product added to your" })).toBeVisible();
-    // Chai assert:
     const addedAlertMessage = await page.getByRole("alert", {
       name: "Product added to your",
     });
+    await addedAlertMessage.waitFor({ state: "visible" });
     const addedIsVisible = await addedAlertMessage.isVisible();
     assert.isTrue(addedIsVisible, "Expected alert 'Product added to your' to be visible");
 
     // And the Combination Pliers are shown in the Favorites page
     await page.goto("account/favorites");
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account/favorites");
-    // Chai assert:
     await page.waitForURL("https://practicesoftwaretesting.com/account/favorites");
     const favoritesURL = await page.url();
     assert.equal(favoritesURL, "https://practicesoftwaretesting.com/account/favorites");
 
-    await expect(page.getByText("Combination Pliers")).toBeVisible();
-    // Chai assert:
     const pliers = await page.getByText("Combination Pliers");
+    await pliers.waitFor({ state: "visible" });
     const pliersisVisible = await pliers.isVisible();
     assert.isTrue(pliersisVisible, "Expected Combination Pliers to be visible.");
 
     // (Remove the product for future re-test)
     await page.locator('[data-test="delete"]').click();
-    await expect(page.getByText("There are no favorites yet.")).toBeVisible();
-    // Chai assert:
     const noFavsMessage = await page.getByText("There are no favorites yet.");
+    await noFavsMessage.waitFor({ state: "visible" });
     const noFavsIsVisible = await noFavsMessage.isVisible();
     assert.isTrue(noFavsIsVisible, "Expected 'There are no favorites yet.' message to be visible");
   });
@@ -100,28 +92,29 @@ test.describe("product details page", () => {
   test("add an out-of-stock product to the cart", async ({ page }) => {
     // And the User is on the Long Nose Pliers page
     await page.goto("/");
-    await expect(page.getByText("Long Nose Pliers")).toBeVisible();
-    // Chai assert:
+    await page.waitForLoadState();
+
     const nosePliers = await page.getByText("Combination Pliers");
+    await nosePliers.waitFor({ state: "visible" });
     const nosePliersIsVisible = await nosePliers.isVisible();
     assert.isTrue(nosePliersIsVisible, "Expected Long Nose Pliers to be visible.");
 
     await page.getByText("Long Nose Pliers").click();
 
     // When the Long Nose Pliers page has the "Out of stock" message
-    await expect(page.locator('[data-test="out-of-stock"]')).toBeVisible();
-    // Chai assert:
     const outOfStock = await page.locator('[data-test="out-of-stock"]');
+    await outOfStock.waitFor({ state: "visible" });
     const outOfStockIsVisible = await outOfStock.isVisible();
     assert.isTrue(outOfStockIsVisible, "Expected Out Of Stock message to be visible.");
 
     // Then the Quantity selector and the "Add to cart" button are disabled
-    await expect(page.locator('[data-test="decrease-quantity"]')).toHaveAttribute("disabled", "");
-    await expect(page.locator('[data-test="increase-quantity"]')).toHaveAttribute("disabled", "");
-    // Chai assert:
-    const decreasedAttr = await page.locator('[data-test="decrease-quantity"]').getAttribute("disabled");
+    const decreasedAttr = await page
+      .locator('[data-test="decrease-quantity"]')
+      .getAttribute("disabled");
     assert.strictEqual(decreasedAttr, "", "Expected 'disabled' attribute on decrease");
-    const increaseAttr = await page.locator('[data-test="increase-quantity"]').getAttribute("disabled");
+    const increaseAttr = await page
+      .locator('[data-test="increase-quantity"]')
+      .getAttribute("disabled");
     assert.strictEqual(increaseAttr, "", "Expected 'disabled' attribute on increase");
   });
 });

--- a/tests/product_details.spec.js
+++ b/tests/product_details.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { assert } from "chai";
 
 test.describe("product details page", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -34,16 +35,31 @@ test.describe("product details page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
+    // Chai assert:
+    await page.waitForURL("https://practicesoftwaretesting.com/account");
+    const accountURL = await page.url();
+    assert.equal(accountURL, "https://practicesoftwaretesting.com/account");
   });
 
   test("user adds a product to Favorites", async ({ page }) => {
     // And the Combination Pliers product is not already in Favorites
     await page.goto("account/favorites");
+    await page.waitForLoadState();
+
     await expect(page.getByText("There are no favorites yet.")).toBeVisible();
+    // Chai assert:
+    const noFavoritesMessage = await page.getByText("There are no favorites yet.");
+    const favoritesisVisible = await noFavoritesMessage.isVisible();
+    assert.isTrue(favoritesisVisible, "Expected 'There are no favorites yet.' message to be visible");
 
     // And the User is on the Combination Pliers page
     await page.goto("/");
     await expect(page.getByText("Combination Pliers")).toBeVisible();
+    // Chai assert:
+    const combinationPliers = await page.getByText("Combination Pliers");
+    const combinationPliersisVisible = await combinationPliers.isVisible();
+    assert.isTrue(combinationPliersisVisible, "Expected Combination Pliers to be visible.");
+
     await page.getByText("Combination Pliers").click();
 
     // When the User adds the Combination Pliers to Favorites
@@ -51,28 +67,61 @@ test.describe("product details page", () => {
 
     // Then the message "Product added to your favorites list." is displayed
     await expect(page.getByRole("alert", { name: "Product added to your" })).toBeVisible();
+    // Chai assert:
+    const addedAlertMessage = await page.getByRole("alert", {
+      name: "Product added to your",
+    });
+    const addedIsVisible = await addedAlertMessage.isVisible();
+    assert.isTrue(addedIsVisible, "Expected alert 'Product added to your' to be visible");
 
     // And the Combination Pliers are shown in the Favorites page
     await page.goto("account/favorites");
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account/favorites");
+    // Chai assert:
+    await page.waitForURL("https://practicesoftwaretesting.com/account/favorites");
+    const favoritesURL = await page.url();
+    assert.equal(favoritesURL, "https://practicesoftwaretesting.com/account/favorites");
+
     await expect(page.getByText("Combination Pliers")).toBeVisible();
+    // Chai assert:
+    const pliers = await page.getByText("Combination Pliers");
+    const pliersisVisible = await pliers.isVisible();
+    assert.isTrue(pliersisVisible, "Expected Combination Pliers to be visible.");
 
     // (Remove the product for future re-test)
     await page.locator('[data-test="delete"]').click();
     await expect(page.getByText("There are no favorites yet.")).toBeVisible();
+    // Chai assert:
+    const noFavsMessage = await page.getByText("There are no favorites yet.");
+    const noFavsIsVisible = await noFavsMessage.isVisible();
+    assert.isTrue(noFavsIsVisible, "Expected 'There are no favorites yet.' message to be visible");
   });
 
   test("add an out-of-stock product to the cart", async ({ page }) => {
     // And the User is on the Long Nose Pliers page
     await page.goto("/");
     await expect(page.getByText("Long Nose Pliers")).toBeVisible();
+    // Chai assert:
+    const nosePliers = await page.getByText("Combination Pliers");
+    const nosePliersIsVisible = await nosePliers.isVisible();
+    assert.isTrue(nosePliersIsVisible, "Expected Long Nose Pliers to be visible.");
+
     await page.getByText("Long Nose Pliers").click();
 
     // When the Long Nose Pliers page has the "Out of stock" message
     await expect(page.locator('[data-test="out-of-stock"]')).toBeVisible();
+    // Chai assert:
+    const outOfStock = await page.locator('[data-test="out-of-stock"]');
+    const outOfStockIsVisible = await outOfStock.isVisible();
+    assert.isTrue(outOfStockIsVisible, "Expected Out Of Stock message to be visible.");
 
     // Then the Quantity selector and the "Add to cart" button are disabled
     await expect(page.locator('[data-test="decrease-quantity"]')).toHaveAttribute("disabled", "");
     await expect(page.locator('[data-test="increase-quantity"]')).toHaveAttribute("disabled", "");
+    // Chai assert:
+    const decreasedAttr = await page.locator('[data-test="decrease-quantity"]').getAttribute("disabled");
+    assert.strictEqual(decreasedAttr, "", "Expected 'disabled' attribute on decrease");
+    const increaseAttr = await page.locator('[data-test="increase-quantity"]').getAttribute("disabled");
+    assert.strictEqual(increaseAttr, "", "Expected 'disabled' attribute on increase");
   });
 });

--- a/tests/product_details.spec.js
+++ b/tests/product_details.spec.js
@@ -34,7 +34,7 @@ test.describe("product details page", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await page.waitForURL("https://practicesoftwaretesting.com/account");
-    const accountURL = await page.url();
+    const accountURL = page.url();
     assert.equal(accountURL, "https://practicesoftwaretesting.com/account");
   });
 
@@ -43,7 +43,7 @@ test.describe("product details page", () => {
     await page.goto("account/favorites");
     await page.waitForLoadState();
 
-    const noFavoritesMessage = await page.getByText("There are no favorites yet.");
+    const noFavoritesMessage = page.getByText("There are no favorites yet.");
     await noFavoritesMessage.waitFor({ state: "visible" });
     const favoritesisVisible = await noFavoritesMessage.isVisible();
     assert.isTrue(
@@ -53,7 +53,7 @@ test.describe("product details page", () => {
 
     // And the User is on the Combination Pliers page
     await page.goto("/");
-    const combinationPliers = await page.getByText("Combination Pliers");
+    const combinationPliers = page.getByText("Combination Pliers");
     await combinationPliers.waitFor({ state: "visible" });
     const combinationPliersisVisible = await combinationPliers.isVisible();
     assert.isTrue(combinationPliersisVisible, "Expected Combination Pliers to be visible.");
@@ -63,7 +63,7 @@ test.describe("product details page", () => {
     // When the User adds the Combination Pliers to Favorites
     await page.locator('[data-test="add-to-favorites"]').click();
 
-    const addedAlertMessage = await page.getByRole("alert", {
+    const addedAlertMessage = page.getByRole("alert", {
       name: "Product added to your",
     });
     await addedAlertMessage.waitFor({ state: "visible" });
@@ -73,17 +73,17 @@ test.describe("product details page", () => {
     // And the Combination Pliers are shown in the Favorites page
     await page.goto("account/favorites");
     await page.waitForURL("https://practicesoftwaretesting.com/account/favorites");
-    const favoritesURL = await page.url();
+    const favoritesURL = page.url();
     assert.equal(favoritesURL, "https://practicesoftwaretesting.com/account/favorites");
 
-    const pliers = await page.getByText("Combination Pliers");
+    const pliers = page.getByText("Combination Pliers");
     await pliers.waitFor({ state: "visible" });
     const pliersisVisible = await pliers.isVisible();
     assert.isTrue(pliersisVisible, "Expected Combination Pliers to be visible.");
 
     // (Remove the product for future re-test)
     await page.locator('[data-test="delete"]').click();
-    const noFavsMessage = await page.getByText("There are no favorites yet.");
+    const noFavsMessage = page.getByText("There are no favorites yet.");
     await noFavsMessage.waitFor({ state: "visible" });
     const noFavsIsVisible = await noFavsMessage.isVisible();
     assert.isTrue(noFavsIsVisible, "Expected 'There are no favorites yet.' message to be visible");
@@ -94,7 +94,7 @@ test.describe("product details page", () => {
     await page.goto("/");
     await page.waitForLoadState();
 
-    const nosePliers = await page.getByText("Combination Pliers");
+    const nosePliers = page.getByText("Combination Pliers");
     await nosePliers.waitFor({ state: "visible" });
     const nosePliersIsVisible = await nosePliers.isVisible();
     assert.isTrue(nosePliersIsVisible, "Expected Long Nose Pliers to be visible.");
@@ -102,7 +102,7 @@ test.describe("product details page", () => {
     await page.getByText("Long Nose Pliers").click();
 
     // When the Long Nose Pliers page has the "Out of stock" message
-    const outOfStock = await page.locator('[data-test="out-of-stock"]');
+    const outOfStock = page.locator('[data-test="out-of-stock"]');
     await outOfStock.waitFor({ state: "visible" });
     const outOfStockIsVisible = await outOfStock.isVisible();
     assert.isTrue(outOfStockIsVisible, "Expected Out Of Stock message to be visible.");

--- a/tests/signup_signin.spec.js
+++ b/tests/signup_signin.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+const { expect: chaiExpect } = require("chai");
 
 test.describe("sign up/sign in tests", () => {
   test("user creates an account", async ({ page }) => {
@@ -30,6 +31,10 @@ test.describe("sign up/sign in tests", () => {
 
     // Then the User gets redirected to the login page
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
+    // Chai:
+    await page.waitForURL("https://practicesoftwaretesting.com/auth/login");
+    const loginURL = await page.url();
+    chaiExpect(loginURL).to.equal("https://practicesoftwaretesting.com/auth/login");
   });
 
   test("invalid Date of Birth when creating an account", async ({ page }) => {
@@ -65,5 +70,11 @@ test.describe("sign up/sign in tests", () => {
         hasText: "Please enter a valid date",
       })
     ).toBeVisible();
+    // Chai:
+    const dobError = await page.locator('[data-test="dob-error"]', {
+      hasText: "Please enter a valid date",
+    });
+    const dobErrorIsVisible = await dobError.isVisible();
+    chaiExpect(dobErrorIsVisible).to.be.true;
   });
 });

--- a/tests/signup_signin.spec.js
+++ b/tests/signup_signin.spec.js
@@ -63,7 +63,7 @@ test.describe("sign up/sign in tests", () => {
     await page.locator('[data-test="register-submit"]').click();
 
     // Then the message "Please enter a valid date in YYYY-MM-DD format." is displayed
-    const dobError = await page.locator('[data-test="dob-error"]', {
+    const dobError = page.locator('[data-test="dob-error"]', {
       hasText: "Please enter a valid date",
     });
     const dobErrorIsVisible = await dobError.isVisible();

--- a/tests/signup_signin.spec.js
+++ b/tests/signup_signin.spec.js
@@ -1,5 +1,5 @@
-import { test, expect } from "@playwright/test";
-const { expect: chaiExpect } = require("chai");
+import { test } from "@playwright/test";
+import { expect as chaiExpect } from "chai";
 
 test.describe("sign up/sign in tests", () => {
   test("user creates an account", async ({ page }) => {
@@ -30,10 +30,8 @@ test.describe("sign up/sign in tests", () => {
     await page.locator('[data-test="register-submit"]').click();
 
     // Then the User gets redirected to the login page
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
-    // Chai:
     await page.waitForURL("https://practicesoftwaretesting.com/auth/login");
-    const loginURL = await page.url();
+    const loginURL = page.url();
     chaiExpect(loginURL).to.equal("https://practicesoftwaretesting.com/auth/login");
   });
 
@@ -65,12 +63,6 @@ test.describe("sign up/sign in tests", () => {
     await page.locator('[data-test="register-submit"]').click();
 
     // Then the message "Please enter a valid date in YYYY-MM-DD format." is displayed
-    await expect(
-      page.locator('[data-test="dob-error"]', {
-        hasText: "Please enter a valid date",
-      })
-    ).toBeVisible();
-    // Chai:
     const dobError = await page.locator('[data-test="dob-error"]', {
       hasText: "Please enter a valid date",
     });

--- a/tests/user_profile.spec.js
+++ b/tests/user_profile.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+const { expect: chaiExpect } = require("chai");
 
 test.describe("user profile", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -34,6 +35,10 @@ test.describe("user profile", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
+    // Chai:
+    await page.waitForURL("https://practicesoftwaretesting.com/account");
+    const accountURL = await page.url();
+    chaiExpect(accountURL).to.equal("https://practicesoftwaretesting.com/account");
   });
 
   test("user updates the profile", async ({ page }) => {
@@ -42,10 +47,27 @@ test.describe("user profile", () => {
     // And the User is on the Profile page
     await page.locator('[data-test="nav-profile"]').click();
     await expect(page).toHaveURL("https://practicesoftwaretesting.com/account/profile");
+    await page.waitForLoadState();
+
+    // Chai:
+    await page.waitForURL("https://practicesoftwaretesting.com/account/profile");
+    const profileURL = await page.url();
+    chaiExpect(profileURL).to.equal("https://practicesoftwaretesting.com/account/profile");
 
     // When the User updates "Street" and "Postal code" fields with valid data
     await expect(page.locator('[data-test="street"]')).toHaveValue(/.+/);
+    // Chai:
+    const streetField = await page.locator('[data-test="street"]');
+    const streetValue = await streetField.inputValue();
+    chaiExpect(streetValue).to.match(/.+/);
+
     await expect(page.locator('[data-test="postal_code"]')).toHaveValue(/.+/);
+    // Chai:
+    const postalCodeField = await page.locator('[data-test="postal_code"]');
+    const postalCodeValue = await postalCodeField.inputValue();
+    chaiExpect(postalCodeValue).to.match(/.+/);
+
+    // Adding new Street and Postal Code:
     await page.locator('[data-test="street"]').fill("Arcos " + `${randomAppend}`);
     await page.locator('[data-test="postal_code"]').fill(randomAppend);
 
@@ -54,5 +76,9 @@ test.describe("user profile", () => {
 
     // Then the message "Your profile is successfully updated!" is displayed
     await expect(page.getByText("Your profile is successfully updated!")).toBeVisible();
+    // Chai:
+    const profileUpdatedMsg = await page.getByText("Your profile is successfully updated!");
+    const updateMsgVisible = await profileUpdatedMsg.isVisible();
+    chaiExpect(updateMsgVisible).to.be.true;
   });
 });

--- a/tests/user_profile.spec.js
+++ b/tests/user_profile.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-const { expect: chaiExpect } = require("chai");
+import { expect as chaiExpect } from "chai";
 
 test.describe("user profile", () => {
   test.beforeEach(async ({ page, context }) => {
@@ -23,10 +23,9 @@ test.describe("user profile", () => {
     try {
       await page.locator('[data-test="register-submit"]').click();
       await expect(page).toHaveURL("https://practicesoftwaretesting.com/auth/login");
-      console.log("cuenta creada");
+      console.log("Account created");
     } catch (err) {
-      await page.getByText("A customer with this email address already exists.");
-      console.log("la cuenta ya estaba creada");
+      console.log("The account was already created");
     }
 
     // Given the user is logged
@@ -34,8 +33,6 @@ test.describe("user profile", () => {
     await page.locator('[data-test="email"]').fill("email@example.com");
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account");
-    // Chai:
     await page.waitForURL("https://practicesoftwaretesting.com/account");
     const accountURL = await page.url();
     chaiExpect(accountURL).to.equal("https://practicesoftwaretesting.com/account");
@@ -46,23 +43,17 @@ test.describe("user profile", () => {
 
     // And the User is on the Profile page
     await page.locator('[data-test="nav-profile"]').click();
-    await expect(page).toHaveURL("https://practicesoftwaretesting.com/account/profile");
-    await page.waitForLoadState();
 
-    // Chai:
     await page.waitForURL("https://practicesoftwaretesting.com/account/profile");
-    const profileURL = await page.url();
+    const profileURL = page.url();
     chaiExpect(profileURL).to.equal("https://practicesoftwaretesting.com/account/profile");
 
     // When the User updates "Street" and "Postal code" fields with valid data
-    await expect(page.locator('[data-test="street"]')).toHaveValue(/.+/);
-    // Chai:
-    const streetField = await page.locator('[data-test="street"]');
+    const streetField = page.locator('[data-test="street"]');
+    await page.waitForLoadState("networkidle");
     const streetValue = await streetField.inputValue();
     chaiExpect(streetValue).to.match(/.+/);
 
-    await expect(page.locator('[data-test="postal_code"]')).toHaveValue(/.+/);
-    // Chai:
     const postalCodeField = await page.locator('[data-test="postal_code"]');
     const postalCodeValue = await postalCodeField.inputValue();
     chaiExpect(postalCodeValue).to.match(/.+/);
@@ -75,9 +66,8 @@ test.describe("user profile", () => {
     await page.locator('[data-test="update-profile-submit"]').click();
 
     // Then the message "Your profile is successfully updated!" is displayed
-    await expect(page.getByText("Your profile is successfully updated!")).toBeVisible();
-    // Chai:
     const profileUpdatedMsg = await page.getByText("Your profile is successfully updated!");
+    await profileUpdatedMsg.waitFor({ state: "visible" });
     const updateMsgVisible = await profileUpdatedMsg.isVisible();
     chaiExpect(updateMsgVisible).to.be.true;
   });

--- a/tests/user_profile.spec.js
+++ b/tests/user_profile.spec.js
@@ -34,7 +34,7 @@ test.describe("user profile", () => {
     await page.locator('[data-test="password"]').fill("123_Tests");
     await page.locator('[data-test="login-submit"]').click();
     await page.waitForURL("https://practicesoftwaretesting.com/account");
-    const accountURL = await page.url();
+    const accountURL = page.url();
     chaiExpect(accountURL).to.equal("https://practicesoftwaretesting.com/account");
   });
 
@@ -54,7 +54,7 @@ test.describe("user profile", () => {
     const streetValue = await streetField.inputValue();
     chaiExpect(streetValue).to.match(/.+/);
 
-    const postalCodeField = await page.locator('[data-test="postal_code"]');
+    const postalCodeField = page.locator('[data-test="postal_code"]');
     const postalCodeValue = await postalCodeField.inputValue();
     chaiExpect(postalCodeValue).to.match(/.+/);
 
@@ -66,7 +66,7 @@ test.describe("user profile", () => {
     await page.locator('[data-test="update-profile-submit"]').click();
 
     // Then the message "Your profile is successfully updated!" is displayed
-    const profileUpdatedMsg = await page.getByText("Your profile is successfully updated!");
+    const profileUpdatedMsg = page.getByText("Your profile is successfully updated!");
     await profileUpdatedMsg.waitFor({ state: "visible" });
     const updateMsgVisible = await profileUpdatedMsg.isVisible();
     chaiExpect(updateMsgVisible).to.be.true;


### PR DESCRIPTION
Implemented Chai's interfaces (Assert, Should and Expect) as follows:

- Expect: signup_signin.spec.js, user_profile.spec.js
- Assert: product_details.spec.js
- Should: checkout.spec.js, home.spec.js

I didn't removed the Playwright assertions as they serve as a way to control timing within the tests. 